### PR TITLE
Fix sponsorship link

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,7 +103,7 @@
           <p>Want to speak at DonutJS? We're accepting proposals <a href='https://github.com/donut-js/donut-js.github.io/issues/8'>here!</a>. Your talk can be anything from knitting machines to the JavaScript v8 engine. And nope, you don’t need to be an expert to speak.</p>
 
           <h2>Sponsors</h2>
-          <p>Donut.js is a not-for-profit event, we use sponsorship money to cover our event materials costs and donate the rest to a local charity. Want to sponsor DonutJS? You can learn more about sponsoring <a href='https://github.com/donut-js/donut-js.github.io/issues/8'>here!</a>
+          <p>Donut.js is a not-for-profit event, we use sponsorship money to cover our event materials costs and donate the rest to a local charity. Want to sponsor DonutJS? You can learn more about sponsoring <a href='https://github.com/donut-js/donut-js.github.io/issues/3'>here!</a>
 
           <h2>Code of Conduct</h2>
           <p>All participants are expected to follow the <a href='http://jsconf.com/codeofconduct.html'>JSConf Code of Conduct</a>. If following this seems silly, please don't attend!</p>


### PR DESCRIPTION
Before, it linked to :point_right: https://github.com/donut-js/donut-js.github.io/issues/8
Now, it links to :point_right: https://github.com/donut-js/donut-js.github.io/issues/3