### PR TITLE
Adding sponsorship package price table to Sponsorship page. And some nitpicky changes.

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -356,6 +356,18 @@ button {
     font-family: 'Mikado', Sans-Serif;
 }
 
+/* Sponsorship - - - - - - - - - - */
+
+.panel table.sponsorship-packages {
+    width: 100%;
+}
+
+.panel table.sponsorship-packages th,
+.panel table.sponsorship-packages td
+{
+    text-align: center;
+}
+
 /* Responsive - - - - - - - - - - */
 @media screen and (max-width: 720px) {
     .donny {
@@ -372,5 +384,8 @@ button {
         display: block;
         padding: 0;
         margin-top: 2rem;
+    }
+    .panel table.sponsorship-packages {
+        font-size: 14px;
     }
 }

--- a/index.html
+++ b/index.html
@@ -31,9 +31,9 @@
           <div class="about">
             <div class="about-description">
               <p>A fun night of code, donuts, and karaoke.</p>
-              <p>The first Donut.js will be April 26th at 6:30PM at <a href='http://www.cupandbar.com/'>Cup &amp; Bar</a> in Inner SE Portland.</p>
+              <p>The first Donut.js will be April 26th at 6:30PM at <a href="http://www.cupandbar.com/">Cup &amp; Bar</a> in Inner SE Portland.</p>
               <p>Tickets are $10 (includes a donut), and leftover proceeds go to a local non-profit.</p>
-              <p class='non-prof-description'>This month's non-profit is <a href='http://portland.chicktech.org/'>ChickTech Portland</a>, an organization that provides mentoring and workshops to Portland area girls interested in STEM fields.</p>
+              <p class="non-prof-description">This month&rsquo;s non-profit is <a href="http://portland.chicktech.org/">ChickTech Portland</a>, an organization that provides mentoring and workshops to Portland area girls interested in STEM fields.</p>
 
               <a class="navigation-link navigation-link-blue" href="./tickets/">Buy Tickets</a>
             </div>
@@ -60,15 +60,15 @@
               </li>
               <li class="event">
                 <p class="event-time">7:30</p>
-                <div class='event-speaker'>
-                Visnu Pitiyanuvath <a href='https://twitter.com/visnup'>@visnup</a>
+                <div class="event-speaker">
+                Visnu Pitiyanuvath <a href="https://twitter.com/visnup">@visnup</a>
                 </div>
-                <div class="event-description">HSL -- the RGB You've Been Waiting For</div>
+                <div class="event-description">HSL -- the RGB You&rsquo;ve Been Waiting For</div>
               </li>
               <li class="event">
                 <p class="event-time">7:45</p>
-                  <div class='event-speaker'>
-                  Stef Hatcher <a href='https://twitter.com/stefhatcher'>@stefhatcher</a>
+                  <div class="event-speaker">
+                  Stef Hatcher <a href="https://twitter.com/stefhatcher">@stefhatcher</a>
                   </div>
                   <div class="event-description">React Meets Accessibility</div>
               <li class="event">
@@ -77,15 +77,15 @@
               </li>
               <li class="event">
                 <p class="event-time">8:15</p>
-                <div class='event-speaker'>
-                Ben Michel <a href='https://twitter.com/obensource'>@obensource</a>
+                <div class="event-speaker">
+                Ben Michel <a href="https://twitter.com/obensource">@obensource</a>
                 </div>
-                <div class="event-description">Remote-performing –– It's a Thing!</div>
+                <div class="event-description">Remote-performing –– It&rsquo;s a Thing!</div>
               </li>
               <li class="event">
                 <p class="event-time">8:30</p>
-                <div class='event-speaker'>
-                Liz Abinante <a href='https://twitter.com/feministy'>@feministy</a>
+                <div class="event-speaker">
+                Liz Abinante <a href="https://twitter.com/feministy">@feministy</a>
                 </div>
                 <div class="event-description">Auto-generating Knitting Patterns with Javascript</div>
               </li>
@@ -100,16 +100,16 @@
         <div class="panel">
 
           <h2>Speak</h2>
-          <p>Want to speak at DonutJS? We're accepting proposals <a href='https://github.com/donut-js/donut-js.github.io/issues/14'>here!</a>. Your talk can be anything from knitting machines to the JavaScript v8 engine. And nope, you don’t need to be an expert to speak.</p>
+          <p>Want to speak at DonutJS? We&rsquo;re accepting proposals <a href="https://github.com/donut-js/donut-js.github.io/issues/14">here!</a>. Your talk can be anything from knitting machines to the JavaScript v8 engine. And nope, you don’t need to be an expert to speak.</p>
 
           <h2>Sponsors</h2>
-          <p>Donut.js is a not-for-profit event, we use sponsorship money to cover our event materials costs and donate the rest to a local charity. Want to sponsor DonutJS? You can learn more about sponsoring <a href='./sponsor/'>here!</a>
+          <p>Donut.js is a not-for-profit event, we use sponsorship money to cover our event materials costs and donate the rest to a local charity. Want to sponsor DonutJS? You can learn more about sponsoring <a href="./sponsor/">here!</a>
 
           <h2>Code of Conduct</h2>
-          <p>All participants are expected to follow the <a href='http://jsconf.com/codeofconduct.html'>JSConf Code of Conduct</a>. If following this seems silly, please don't attend!</p>
+          <p>All participants are expected to follow the <a href="http://jsconf.com/codeofconduct.html">JSConf Code of Conduct</a>. If following this seems silly, please don&rsquo;t attend!</p>
 
           <h2>Organizing</h2>
-          <p>To contact the organizers, or if you'd like to get involved, check out some of our <a href="https://github.com/donutjs/donutjs.github.io/issues">open GitHub issues</a> where we are discussing speakers, sponsorships, etc. Or reach out to Emily <a href="https://twitter.com/emplums">@emplums</a> or Max <a href="https://twitter.com/denormalize">@denormalize</a> on twitter!</p>
+          <p>To contact the organizers, or if you&rsquo;d like to get involved, check out some of our <a href="https://github.com/donutjs/donutjs.github.io/issues">open GitHub issues</a> where we are discussing speakers, sponsorships, etc. Or reach out to Emily <a href="https://twitter.com/emplums">@emplums</a> or Max <a href="https://twitter.com/denormalize">@denormalize</a> on twitter!</p>
 
         </div>
 

--- a/perform/index.html
+++ b/perform/index.html
@@ -30,13 +30,13 @@
         <div class="panel">
           <h1>Come Perform!</h1>
 
-          <p>We're looking for people to perform at our meetup!</p>
+          <p>We&rsquo;re looking for people to perform at our meetup!</p>
 
           <h2>How do I submit a performance?</h2>
           <p>Comment on <a href="https://github.com/donut-js/donut-js.github.io/issues/7">this thread</a>!</p>
 
           <h2>What kind of performance are you looking for?</h2>
-          <p>It can be karaoke, plate-spinning, or fire-eating. Basically anything you want. If you're into, we're into it.</p>
+          <p>It can be karaoke, plate-spinning, or fire-eating. Basically anything you want. If you&rsquo;re into, we&rsquo;re into it.</p>
 
           <h2>How long should my performance be?</h2>
           <p>It should be &lt;6 min long!</p>
@@ -45,7 +45,7 @@
           <p>Nope. You just need to be enthusiastic!</p>
 
           <h2>What should be in my submission?</h2>
-          <p>A description of what you'll be performing and what kind of equipment you'll need.</p>
+          <p>A description of what you&rsquo;ll be performing and what kind of equipment you&rsquo;ll need.</p>
         </div>
       </div>
     </div>

--- a/speak/index.html
+++ b/speak/index.html
@@ -35,7 +35,7 @@
           <h2>How do I submit a talk?</h2>
           <p>You can either comment on <a href="https://github.com/donut-js/donut-js.github.io/issues/14">this issue</a> or send us an <a href="mailto:hello@donutjs.club">email</a>.</p>
 
-          <h2>When/where is it</h2>
+          <h2>When/where is it?</h2>
           <p>April 26th, at 6:30 at Cup and Bar! But if we get too many proposals and we really love your talk, we'd be happy to schedule you for a later month!</p>
 
           <h2>What should I talk about?</h2>

--- a/speak/index.html
+++ b/speak/index.html
@@ -30,13 +30,13 @@
         <div class="panel">
           <h1>Come Speak!</h1>
 
-          <p>We're looking for speakers for our meetup!</p>
+          <p>We&rsquo;re looking for speakers for our meetup!</p>
 
           <h2>How do I submit a talk?</h2>
           <p>You can either comment on <a href="https://github.com/donut-js/donut-js.github.io/issues/14">this issue</a> or send us an <a href="mailto:hello@donutjs.club">email</a>.</p>
 
           <h2>When/where is it?</h2>
-          <p>April 26th, at 6:30 at Cup and Bar! But if we get too many proposals and we really love your talk, we'd be happy to schedule you for a later month!</p>
+          <p>April 26th, at 6:30 at Cup and Bar! But if we get too many proposals and we really love your talk, we&rsquo;d be happy to schedule you for a later month!</p>
 
           <h2>What should I talk about?</h2>
           <p>We don’t have a strict formula, but this is the balance we try to strike every month:</p>
@@ -54,7 +54,7 @@
           <p>Nope. This meetup is supposed to be fun and casual, so we want everyone to participate. We especially encourage people of underrepresented groups to apply!</p>
 
           <h2>How long should my talk be?</h2>
-          <p>Ten minutes. There won't be any formal Q&amp;A.</p>
+          <p>Ten minutes. There won&rsquo;t be any formal Q&amp;A.</p>
 
           <h2>What should be in my talk submission?</h2>
           <p>Just a few sentences describing what you want to talk about would be great.</p>

--- a/sponsor/index.html
+++ b/sponsor/index.html
@@ -37,7 +37,7 @@
           <li>Your logo on our website and in our emails to attendees</li>
           </ul>
 
-          <p>If you'd like to be a sponsor, please contact us at <a href='mailto:hello@donutjs.club'>hello@donutjs.club</a></p>
+          <p>If you&rsquo;d like to be a sponsor, please contact us at <a href="mailto:hello@donutjs.club">hello@donutjs.club</a></p>
         </div>
       </div>
     </div>

--- a/sponsor/index.html
+++ b/sponsor/index.html
@@ -29,7 +29,7 @@
 
         <div class="panel">
           <h1>Sponsoring DonutJS!</h1>
-          <p>Each month DonutJS is sponsored by 2-3 generous companies! We use these funds to cover food, venue costs, and equipment. All leftover proceeds from ticket sales and outside funds are donated to a non-profit in the community. Sponsorship starts at $500 for one month, with discounts for companies that would like to sponsor for multiple months.</p>
+          <p>Each month DonutJS is sponsored by 2&ndash;3 generous companies! We use these funds to cover food, venue costs, and equipment. All leftover proceeds from ticket sales and outside funds are donated to a non-profit in the community. Sponsorship starts at $500 for one month, with discounts for companies that would like to sponsor for multiple months.</p>
 
           <h2>Sponsorship Packages</h2>
           <table class="sponsorship-packages">

--- a/sponsor/index.html
+++ b/sponsor/index.html
@@ -31,10 +31,34 @@
           <h1>Sponsoring DonutJS!</h1>
           <p>Each month DonutJS is sponsored by 2-3 generous companies! We use these funds to cover food, venue costs, and equipment. All leftover proceeds from ticket sales and outside funds are donated to a non-profit in the community. Sponsorship starts at $500 for one month, with discounts for companies that would like to sponsor for multiple months.</p>
 
+          <h2>Sponsorship Packages</h2>
+          <table class="sponsorship-packages">
+            <thead>
+              <tr>
+                <th>1 Month</th>
+                <th>3 Months</th>
+                <th>6 Months</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>$500 total</td>
+                <td>$1,350 total</td>
+                <td>$2,400 total</td>
+              </tr>
+              <tr>
+                <td>Full Price</td>
+                <td>Save 10%</td>
+                <td>Save 20%</td>
+              </tr>
+            </tbody>
+          </table>
+
           <h2>Sponsorship includes:</h2>
-          <ul><li>2 minutes to speak to the audience about your product, hiring, etc.</li>
-          <li>A space at the event to give out swag</li>
-          <li>Your logo on our website and in our emails to attendees</li>
+          <ul>
+            <li>2 minutes to speak to the audience about your product, hiring, etc.</li>
+            <li>A space at the event to give out swag</li>
+            <li>Your logo on our website and in our emails to attendees</li>
           </ul>
 
           <p>If you&rsquo;d like to be a sponsor, please contact us at <a href="mailto:hello@donutjs.club">hello@donutjs.club</a></p>

--- a/sponsor/index.html
+++ b/sponsor/index.html
@@ -24,7 +24,7 @@
           <a class="navigation-link navigation-link-pink navigation-link-home" href="../index.html">Home</a>
           <a class="navigation-link navigation-link-green" href="../speak/">Speak</a>
           <a class="navigation-link navigation-link-yellow" href="../perform/">Perform</a>
-          <a class="navigation-link navigation-link-blue" href="./sponsor/">Sponsor</a>
+          <a class="navigation-link navigation-link-blue" href="../sponsor/">Sponsor</a>
         </nav>
 
         <div class="panel">

--- a/tickets/index.html
+++ b/tickets/index.html
@@ -6,7 +6,7 @@
     <title>Buy Tickets | DonutJS</title>
     <link href="../css/main.css" rel="stylesheet">
     <link rel="shortcut icon" type="image/png" href="../favicon.png"/>
-    <link rel="stylesheet" type="text/css" href='https://css.tito.io/v1' />
+    <link rel="stylesheet" type="text/css" href="https://css.tito.io/v1" />
   </head>
   <body>
 
@@ -38,6 +38,6 @@
     <!-- generated sprinkles! -->
     <canvas id="sprinkles" class="sprinkles"></canvas>
     <script src="../js/sprinkles.js"></script>
-    <script src='https://js.tito.io/v1' async></script>
+    <script src="https://js.tito.io/v1" async></script>
   </body>
 </html>


### PR DESCRIPTION
- Adds the sponsorship package pricing table to the Sponsorship page.
- Fixes a broken link in the navigation on the Sponsorship page.
- Adds a missing question mark on the Speak page.
- Makes consistent the use of "double quotes" in HTML tag attributes and the user of ‘curly quotes’ in copy.